### PR TITLE
Настройка `structlog`

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2099,6 +2099,24 @@ anyio = ">=3.4.0,<5"
 full = ["itsdangerous", "jinja2", "python-multipart", "pyyaml", "requests"]
 
 [[package]]
+name = "structlog"
+version = "23.1.0"
+description = "Structured Logging for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "structlog-23.1.0-py3-none-any.whl", hash = "sha256:79b9e68e48b54e373441e130fa447944e6f87a05b35de23138e475c05d0f7e0e"},
+    {file = "structlog-23.1.0.tar.gz", hash = "sha256:270d681dd7d163c11ba500bc914b2472d2b50a8ef00faa999ded5ff83a2f906b"},
+]
+
+[package.extras]
+dev = ["structlog[docs,tests,typing]"]
+docs = ["furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-mermaid", "twisted"]
+tests = ["coverage[toml]", "freezegun (>=0.2.8)", "pretend", "pytest (>=6.0)", "pytest-asyncio (>=0.17)", "simplejson"]
+typing = ["mypy", "rich", "twisted"]
+
+[[package]]
 name = "tornado"
 version = "6.2"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
@@ -2353,4 +2371,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "12ffcf62c976a37e4773a4ab2ca3c870d05025c993b271ade064448788fe2d3a"
+content-hash = "f7ead47f54d5aff34540a9ab8590d7177aeff7808ed9fb4d4a6021a48f056261"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ pyjwt = "^2.6.0"
 celery = "^5.2.7"
 redis = "^4.5.4"
 flower = "^1.2.0"
+structlog = "^23.1.0"
 
 [tool.poetry.group.prod]
 optional = true

--- a/src/bot/__init__.py
+++ b/src/bot/__init__.py
@@ -1,0 +1,5 @@
+import bot.handlers.loggers
+
+
+def __dummy():
+    repr(bot.handlers.loggers)

--- a/src/bot/handlers/loggers.py
+++ b/src/bot/handlers/loggers.py
@@ -1,36 +1,65 @@
-import logging
-import sys
-from logging.handlers import RotatingFileHandler
+from functools import partial
+from json import dumps
+from os import getpid
+from typing import TextIO
 
-STR_FORMAT = "[%(asctime)s] %(filename)s:%(lineno)d " "[%(levelname)s] %(message)s"
-DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+import structlog
+from structlog import PrintLogger
+from structlog.contextvars import merge_contextvars
+from structlog.processors import (
+    add_log_level, TimeStamper, UnicodeDecoder, JSONRenderer
+)
 
-Errors_log_file = "ERRORS_file.log"
+from core.config import settings
 
-
-def backoff_loger():
-    logger = logging.getLogger("backoff")
-    file_handler = RotatingFileHandler(Errors_log_file, maxBytes=10**4, backupCount=5)
-    file_handler.setLevel(logging.ERROR)
-    error_formatter = logging.Formatter("%(asctime)s - %(name)s " "- %(levelname)s %(message)s")
-    file_handler.setFormatter(error_formatter)
-    logger.addHandler(file_handler)
-    return logger
+DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 
 
-def get_logger(logger_name=__file__):
-    """Создание и настройка логгера."""
-    # Create a custom logger
-    logger = logging.getLogger(logger_name)
-    # Create handlers
-    console_handler = logging.StreamHandler(stream=sys.stdout)
-    # Create levels
-    console_handler.setLevel(logging.DEBUG)
-    # Create formatters
-    formatter = logging.Formatter(fmt=STR_FORMAT, datefmt=DATE_FORMAT)
-    # Add formatters to handlers
-    console_handler.setFormatter(formatter)
-    # Add handlers to  the logger
-    logger.addHandler(console_handler)
+class _DualWriter(TextIO):
+    def __init__(self, filename, mode="a", encoding="utf-8"):
+        self._filename = filename
+        self._mode = mode
+        self._encoding = encoding
 
-    return logger
+    def write(self, data):
+        with open(
+                file=self._filename,
+                mode=self._mode,
+                encoding=self._encoding,
+        ) as file:
+            file.write(data)
+            print(data, end="")
+
+    def __getattr__(self, item):
+        return self.pass_
+
+    def pass_(self, *args, **kwargs):
+        pass
+
+
+def add_pid(logger, log_method, event_dict):
+    event_dict["pid"] = getpid()
+    return event_dict
+
+
+add_timestamp = TimeStamper(fmt=DATETIME_FORMAT, utc=False)
+
+structlog.configure(
+    processors=[
+        merge_contextvars,
+        add_pid,
+        add_log_level,
+        add_timestamp,
+        UnicodeDecoder(),
+        JSONRenderer(serializer=partial(dumps, ensure_ascii=False)),
+    ],
+    logger_factory=lambda *args: PrintLogger(
+        file=_DualWriter(
+            filename=settings.log_file,
+            encoding=settings.log_encoding,
+        )
+    ),
+    wrapper_class=structlog.make_filtering_bound_logger(settings.log_level)
+)
+
+logger: PrintLogger = structlog.getLogger(settings.logger_name)

--- a/src/core/backoff.py
+++ b/src/core/backoff.py
@@ -1,8 +1,9 @@
 import backoff
+from structlog import get_logger
 
-from bot.handlers.loggers import backoff_loger
+from core.config import settings
 
-logger = backoff_loger()
+logger = get_logger(settings.logger_name)
 
 """
 Base_method - арифметическая прогрессия.
@@ -15,12 +16,9 @@ JITTER = {"Base_method": None, "RandomJitter_method": backoff.random_jitter, "Fu
 
 
 def backoff_hdlr(details):
-    tries = details.get("tries")
-    wait = float("{:.3f}".format(details.get("wait")))
-    elapsed = float("{:.3f}".format(details.get("elapsed")))
     logger.error(
-        f"\nDatabase crash:\n"
-        f"{tries} attempt to connect to base\n"
-        f"Wait time {wait}\n"
-        f"Total waiting time {elapsed} seconds"
+        "Database crash",
+        tries=details.get("tries"),
+        wait_time=float("{:.3f}".format(details.get("wait"))),
+        total_waiting_time=float("{:.3f}".format(details.get("elapsed"))),
     )

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -1,3 +1,5 @@
+from logging import INFO
+
 from dotenv import load_dotenv
 from pydantic import BaseSettings
 
@@ -27,6 +29,12 @@ class Settings(BaseSettings):
     redis_host: str | None = "redis"
     redis_port: str | None = "6379"
     celery_connect_string = 'redis://{}:{}/0'
+
+    # Logging
+    logger_name: str = "bot"
+    log_file: str | None = "bot.log"
+    log_level: int | None = INFO
+    log_encoding: str | None = "utf-8"
 
     class Config:
         env_file = ".env"

--- a/src/core/db/repository/abstract_repository.py
+++ b/src/core/db/repository/abstract_repository.py
@@ -1,9 +1,10 @@
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from structlog import get_logger
 
-from bot.handlers.loggers import get_logger
+from core.config import settings
 
-logger = get_logger()
+logger = get_logger(settings.logger_name)
 
 
 class CRUDBase:

--- a/src/core/db/repository/user_repository.py
+++ b/src/core/db/repository/user_repository.py
@@ -2,12 +2,9 @@ import backoff
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from bot.handlers.loggers import get_logger
 from src.core.backoff import JITTER, backoff_hdlr
 from src.core.db.model import User
 from src.core.db.repository.abstract_repository import CRUDBase
-
-logger = get_logger()
 
 
 class UserCRUD(CRUDBase):


### PR DESCRIPTION
Настройка structlog в проекте. В будущем можно будет создать удобное логгирование которое будет хорошо работать с LogQL.
Пример использования настроенного логирования:

```python
from structlog import get_logger

from core.config import settings


logger = get_logger(settings.logger_name)

logger.info('EVENT', foo='bar')
``` 